### PR TITLE
Adding droplet creation error handling

### DIFF
--- a/vpn_manager.sh
+++ b/vpn_manager.sh
@@ -145,20 +145,8 @@ function create_droplet() {
         exit 1
     fi
 
-    if [[ $? -ne 0 ]]; then
-        echo "Error: Failed to create droplet."
-        exit 1
-    fi
-
-    local droplet_id
-    droplet_id=$(echo "$response" | jq -r '.droplet.id')
-
-    if [[ -z "$droplet_id" ]]; then
-        echo "Error: Failed to retrieve droplet ID."
-        exit 1
-    fi
-
     echo "Droplet created with ID: $droplet_id"
+
 
     # Wait for droplet to become active and assign IP
     local droplet_ip

--- a/vpn_manager.sh
+++ b/vpn_manager.sh
@@ -121,6 +121,29 @@ function create_droplet() {
             "ipv6": true,
             "tags": ["'"$TAG"'"]
         }')
+    
+    # Check if the API call was successful
+    if [[ $? -ne 0 ]]; then
+        echo "Error: Failed to create droplet."
+        exit 1
+    fi
+
+    # Check for error message in response
+    error_message=$(echo "$response" | jq -r '.message // empty')
+    if [[ -n "$error_message" ]]; then
+        echo "Error from DigitalOcean API: $error_message"
+        echo "Full response: $response"
+        exit 1
+    fi
+
+    # Extract the droplet ID
+    droplet_id=$(echo "$response" | jq -r '.droplet.id')
+
+    if [[ -z "$droplet_id" ]]; then
+        echo "Error: Failed to retrieve droplet ID."
+        echo "Full response: $response"
+        exit 1
+    fi
 
     if [[ $? -ne 0 ]]; then
         echo "Error: Failed to create droplet."


### PR DESCRIPTION
I encountered an error while creating a droplet, and the script was failing due to multiple issues with the droplet name. I have modified the script to echo the exact error, which will help users identify the issue during droplet creation.